### PR TITLE
Use defined predicate in #elif

### DIFF
--- a/CtrlBus.h
+++ b/CtrlBus.h
@@ -8,7 +8,7 @@
 #ifdef WIN32
 #include <QSharedMemory>
 #include <QTimer>
-#elif BUILD_SERVICE
+#elif defined(BUILD_SERVICE)
 #include <QtDBus/QtDBus>
 #endif
 


### PR DESCRIPTION
I was getting a compilation error on Arch Linux:

```[ 80%] Building CXX object CMakeFiles/RyzenCtrl.dir/RyzenCtrl_autogen/EWIEGA46WW/qrc_RyzenCtrl.cpp.o
In file included from /home/ro/.cache/paru/clone/ryzenctrl-git/src/xodj-RyzenAdjCtrl/CtrlService.h:13,
                 from /home/ro/.cache/paru/clone/ryzenctrl-git/src/xodj-RyzenAdjCtrl/CtrlService.cpp:1:
/home/ro/.cache/paru/clone/ryzenctrl-git/src/xodj-RyzenAdjCtrl/CtrlBus.h:11:20: error: #elif with no expression
   11 | #elif BUILD_SERVICE
      |                    ^
```

This simple change fixed it for me.